### PR TITLE
Add SendableTrigger class

### DIFF
--- a/src/main/java/frc/robot/telemetry/SendableTrigger.java
+++ b/src/main/java/frc/robot/telemetry/SendableTrigger.java
@@ -1,0 +1,27 @@
+package frc.robot.telemetry;
+
+import java.util.function.BooleanSupplier;
+
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.wpilibj.event.EventLoop;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+
+/** A wrapper for Triggers that implements the Sendable interface, so it can be used for telemetry. */
+public class SendableTrigger extends Trigger implements Sendable {
+
+    public SendableTrigger(BooleanSupplier condition) {
+        super(condition);
+    }
+
+    public SendableTrigger(EventLoop loop, BooleanSupplier condition) {
+        super(loop, condition);
+    }
+
+    @Override
+    public void initSendable(SendableBuilder builder) {
+        builder.setSmartDashboardType("Trigger");
+        builder.addBooleanProperty("value", this::getAsBoolean, null); // SendableBuilder is null-safe (checked source) --ajs 2024-08-16
+    }
+
+}


### PR DESCRIPTION
By declaring a Trigger as a `SendableTrigger` (a one-line change to a subsystem) and using `SmartDashboard.putData()` or any other consumer of `Sendable`s, the state expressed in the relevant Trigger will automatically be kept up to date by the event loop.

```java 
// WidgetorSubsystem
public SendableTrigger motorSpinning() {
	return new SendableTrigger(this.motor1.isSpinning());
}
```

And in its constructor (or maybe RobotContainer if you want to make it conditional):
```java
SmartDashboard.putData("WidgetorSubsystem/motorSpinning", motorSpinning());
```

And to use it, it's the same as a regular Trigger:
```java
// RobotContainer
WidgetorSubsystem widgets = new WidgetorSubsystem();
LEDSubsystem lights = new LEDSubsystem();

// ...
public void configureBindings() {
	widgets.motorSpinning().onTrue(lights.setRedCommand());
}
```
